### PR TITLE
Update to rten v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "rten"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a6dac3f93209d93dbd51b9f0fc0242a7efd2cc5d4dfb187060acca12fae481"
+checksum = "67842141586c527d25547bbd81ccfd60601940281a792bce14a3f72dc15a3fec"
 dependencies = [
  "flatbuffers",
  "libm",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "rten-imageio"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecd318809436643b77248509d663bea976c98655498fd5f539a8b55a6e43535"
+checksum = "807c033f3941fb4401f524a1ad2fc9395c441399d210707c427384413cf1f360"
 dependencies = [
  "image",
  "png",
@@ -427,27 +427,27 @@ dependencies = [
 
 [[package]]
 name = "rten-imageproc"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13625923b2da7c2be5e242c55e623a6cb1a9f85f84c9325f0de80741d6def0da"
+checksum = "d9ceab28b8dcb8925ebc6e51f0038fd16e1cd68229e596eadef826ec7794747f"
 dependencies = [
  "rten-tensor",
 ]
 
 [[package]]
 name = "rten-tensor"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b719a88c81ebfcfca2d291ddad66ef03a51c46116b2371fd7dfd3726252a7554"
+checksum = "b00a55ca04d3219957737f87a9fc3f6eee6770e1f1643c2094c032c90c43f0d2"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "rten-vecmath"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf88099bfb2abd791a65fbb2d4e6415630d307a54dcb3e47d52758f895d1a0c"
+checksum = "1ae896b8b5bea024dab45f9c8ee71051dfbf2a20a83b0e4e48cea5c4e7096e84"
 
 [[package]]
 name = "rustc_version"

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/robertknight/ocrs"
 image = { version = "0.24.6", default-features = false, features = ["png", "jpeg", "jpeg_rayon", "webp"] }
 png = "0.17.6"
 serde_json = "1.0.91"
-rten = { version = "0.2.0" }
-rten-imageproc = { version = "0.1.0" }
-rten-tensor = { version = "0.1.0" }
+rten = { version = "0.3.1" }
+rten-imageproc = { version = "0.3.0" }
+rten-tensor = { version = "0.3.0" }
 ocrs = { path = "../ocrs", version = "0.3.0" }
 lexopt = "0.3.0"
 ureq = "2.7.1"

--- a/ocrs-cli/src/output.rs
+++ b/ocrs-cli/src/output.rs
@@ -1,4 +1,5 @@
 use rten_imageproc::{min_area_rect, Painter, Point, PointF, Rgb, RotatedRect};
+use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 use serde_json::json;
 

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/robertknight/ocrs"
 
 [dependencies]
 rayon = "1.7.0"
-rten = { version = "0.2.0" }
-rten-imageproc = { version = "0.1.0" }
-rten-tensor = { version = "0.1.0" }
+rten = { version = "0.3.1" }
+rten-imageproc = { version = "0.3.0" }
+rten-tensor = { version = "0.3.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.87"
@@ -20,7 +20,7 @@ wasm-bindgen = "0.2.87"
 [dev-dependencies]
 fastrand = "1.9.0"
 lexopt = "0.3.0"
-rten-imageio = { version = "0.1.0" }
+rten-imageio = { version = "0.3.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/ocrs/examples/hello_ocr.rs
+++ b/ocrs/examples/hello_ocr.rs
@@ -5,6 +5,7 @@ use std::fs;
 use ocrs::{OcrEngine, OcrEngineParams};
 use rten::Model;
 use rten_imageio::read_image;
+use rten_tensor::prelude::*;
 
 struct Args {
     image: String,

--- a/ocrs/src/detection.rs
+++ b/ocrs/src/detection.rs
@@ -130,7 +130,7 @@ impl TextDetector {
         // Resize probability mask to original input size and apply threshold to get a
         // binary text/not-text mask.
         let text_mask = text_mask
-            .slice((
+            .slice::<4, _>((
                 ..,
                 ..,
                 ..(in_height - pad_bottom as usize),
@@ -146,8 +146,7 @@ impl TextDetector {
         // objects.
         let expand_dist = 3.;
 
-        let word_rects =
-            find_connected_component_rects(binary_mask.slice([0, 0]).nd_view(), expand_dist);
+        let word_rects = find_connected_component_rects(binary_mask.slice([0, 0]), expand_dist);
 
         Ok(word_rects)
     }
@@ -156,6 +155,7 @@ impl TextDetector {
 #[cfg(test)]
 mod tests {
     use rten_imageproc::{fill_rect, Point};
+    use rten_tensor::prelude::*;
     use rten_tensor::NdTensor;
 
     use super::find_connected_component_rects;

--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 
 use rten::Model;
 use rten_imageproc::RotatedRect;
+use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
 mod detection;

--- a/ocrs/src/wasm_api.rs
+++ b/ocrs/src/wasm_api.rs
@@ -120,8 +120,12 @@ impl OcrEngine {
             return Err("expected channel count to be 1, 3 or 4".to_string());
         }
 
-        let tensor = NdTensorView::from_slice(data, [height, width, channels], None)
-            .map_err(|_| "incorrect data length for image size and channel count".to_string())?
+        let shape = [height, width, channels];
+        if data.len() < shape.iter().product() {
+            return Err("incorrect data length for image size and channel count".to_string());
+        }
+
+        let tensor = NdTensorView::from_data(shape, data)
             .permuted([2, 0, 1]) // HWC => CHW
             .map(|x| (*x as f32) / 255.);
         self.engine


### PR DESCRIPTION
Adapt to rten unified tensor changes:

 - The `view` function is now part of the prelude
 - The `slice` method has now been split into two, depending on whether a static or dynamic-rank result is required
 - `NdTensor::from_data` now has the same signature as `Tensor::from_data`