### PR TITLE
Actually check E2E test output, add more context to output errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +315,7 @@ dependencies = [
 name = "ocrs-cli"
 version = "0.4.0"
 dependencies = [
+ "anyhow",
  "home",
  "image",
  "lexopt",

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ test:
 
 .PHONY: test-e2e
 test-e2e:
-	# TODO - Actually check the output is correct
-	cargo run --release -p ocrs-cli ocrs-cli/test-data/why-rust.png
+	cargo run --release -p ocrs-cli ocrs-cli/test-data/why-rust.png -o /tmp/why-rust.txt
+	diff --ignore-space-change -u /tmp/why-rust.txt ocrs-cli/test-data/why-rust.expected.txt
 
 .PHONY: wasm
 wasm:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TMPDIR := $(or $(RUNNER_TEMP),/tmp)
+
 .PHONY: build
 build:
 	cargo build
@@ -24,8 +26,8 @@ test:
 
 .PHONY: test-e2e
 test-e2e:
-	cargo run --release -p ocrs-cli ocrs-cli/test-data/why-rust.png -o /tmp/why-rust.txt
-	diff --ignore-space-change -u /tmp/why-rust.txt ocrs-cli/test-data/why-rust.expected.txt
+	cargo run --release -p ocrs-cli ocrs-cli/test-data/why-rust.png -o $(TMPDIR)/why-rust.txt
+	diff --ignore-space-change -u $(TMPDIR)/why-rust.txt ocrs-cli/test-data/why-rust.expected.txt
 
 .PHONY: wasm
 wasm:

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -20,6 +20,7 @@ lexopt = "0.3.0"
 ureq = "2.7.1"
 url = "2.4.0"
 home = "0.5.9"
+anyhow = "1.0.79"
 
 [[bin]]
 name = "ocrs"

--- a/ocrs-cli/src/models.rs
+++ b/ocrs-cli/src/models.rs
@@ -1,15 +1,16 @@
-use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use anyhow::anyhow;
 use rten::Model;
 use url::Url;
 
 /// Return the path to the directory in which cached models etc. should be
 /// saved.
-fn cache_dir() -> Result<PathBuf, Box<dyn Error>> {
-    let mut cache_dir: PathBuf = home::home_dir().ok_or("failed to determine home directory")?;
+fn cache_dir() -> Result<PathBuf, anyhow::Error> {
+    let mut cache_dir: PathBuf =
+        home::home_dir().ok_or(anyhow!("Failed to determine home directory"))?;
     cache_dir.push(".cache");
     cache_dir.push("ocrs");
 
@@ -32,11 +33,11 @@ fn filename_from_url(url: &str) -> Option<String> {
 
 /// Download a file from `url` to a local cache, if not already fetched, and
 /// return the path to the local file.
-fn download_file(url: &str, filename: Option<&str>) -> Result<PathBuf, Box<dyn Error>> {
+fn download_file(url: &str, filename: Option<&str>) -> Result<PathBuf, anyhow::Error> {
     let cache_dir = cache_dir()?;
     let filename = match filename {
         Some(fname) => fname.to_string(),
-        None => filename_from_url(url).ok_or("Could not get destination filename")?,
+        None => filename_from_url(url).ok_or(anyhow!("Could not get destination filename"))?,
     };
     let file_path = cache_dir.join(filename);
     if file_path.exists() {
@@ -81,7 +82,7 @@ impl<'a> fmt::Display for ModelSource<'a> {
 ///
 /// If the source is a URL, the model will be downloaded and cached locally if
 /// needed.
-pub fn load_model(source: ModelSource) -> Result<Model, Box<dyn Error>> {
+pub fn load_model(source: ModelSource) -> Result<Model, anyhow::Error> {
     let model_path = match source {
         ModelSource::Url(url) => download_file(url, None)?,
         ModelSource::Path(path) => path.into(),

--- a/ocrs-cli/test-data/why-rust.expected.txt
+++ b/ocrs-cli/test-data/why-rust.expected.txt
@@ -1,0 +1,22 @@
+Why Rust?
+Performance
+[
+Rust is blazingly fast and memory-
+efficient: with no runtime or garbage
+collector, it can power performance-
+critical services, run on embedded
+devices, and easily integrate with other
+languages.
+Reliability
+Rust's rich type system and ownership
+model guarantee memory-safety and
+thread-safety  enabling you to eliminate
+many classes of bugs at compile-time.
+Productivity
+Rust has great documentation, a friendly
+compiler with useful error messages, and
+top-notch tooling an integrated
+package manager and build tool, smart
+multi-editor support with auto-
+completion and type inspections, an
+auto-formatter, and more.


### PR DESCRIPTION
Make `make test-e2e` actually check the text produced against expectations.

In the process of debugging a CI failure, the error messages produced when writing the output file fails have also been improved.