### PR TITLE
Check for `wasm-bindgen.exe` on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
-      run: which wasm-bindgen || cargo install wasm-bindgen-cli
+      run: |
+        which wasm-bindgen || true
+        which wasm-bindgen.exe || true
+        which wasm-bindgen || which wasm-bindgen.exe || cargo install wasm-bindgen-cli
     - name: Build
       run: cargo build
     - name: WASM build


### PR DESCRIPTION
Include extension when testing for pre-built wasm-bindgen in cache.