### PR TITLE
Make `--text-line-images` debug option apply recognition preprocessing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "autocfg"
@@ -301,6 +301,7 @@ dependencies = [
 name = "ocrs"
 version = "0.4.0"
 dependencies = [
+ "anyhow",
  "fastrand",
  "lexopt",
  "rayon",

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/robertknight/ocrs"
 repository = "https://github.com/robertknight/ocrs"
 
 [dependencies]
+anyhow = "1.0.80"
 rayon = "1.7.0"
 rten = { version = "0.4.0" }
 rten-imageproc = { version = "0.4.0" }

--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -158,6 +158,28 @@ impl OcrEngine {
         }
     }
 
+    /// Prepare an image for input into the text line recognition model.
+    ///
+    /// This method exists to help with debugging recognition issues by exposing
+    /// the preprocessing that [OcrEngine::recognize_text] does before it feeds
+    /// an image into the recognition model. Use [OcrEngine::recognize_text] to
+    /// recognize text.
+    ///
+    /// `line` is a sequence of [RotatedRect]s that make up a line of text.
+    ///
+    /// Returns a greyscale (H, W) image with values in [-0.5, 0.5].
+    pub fn prepare_recognition_input(
+        &self,
+        input: &OcrInput,
+        line: &[RotatedRect],
+    ) -> Result<NdTensor<f32, 2>, Box<dyn Error>> {
+        let Some(recognizer) = self.recognizer.as_ref() else {
+            return Err("Recognition model not loaded".into());
+        };
+        let line_image = recognizer.prepare_input(input.image.view(), line);
+        Ok(line_image)
+    }
+
     /// Convenience API that extracts all text from an image as a single string.
     pub fn get_text(&self, input: &OcrInput) -> Result<String, Box<dyn Error>> {
         let word_rects = self.detect_words(input)?;


### PR DESCRIPTION
Make the `--text-line-images` debug option apply the same preprocessing that is applied before lines are fed into the text recognition model. This includes:

 - Resizing the image to be 64px high and with a max width of 800px
 - Converting the image from color to gray
 - Extracting only the polygon containing the line's words, and masking off other pixels in black

This makes this option more useful for debugging recognition accuracy issues, as problems arising from the preprocessing become visible.