### PR TITLE
Update to rten v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "rten"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602e8ac97ee394ef892bf6f0ef8ea87faa79848a67b320eb6d74d10ad462e033"
+checksum = "17e83148868c7361a0008253ff00b960c931ef86c48a3787df6225e521ec5a66"
 dependencies = [
  "flatbuffers",
  "libm",

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/robertknight/ocrs"
 image = { version = "0.24.6", default-features = false, features = ["png", "jpeg", "jpeg_rayon", "webp"] }
 png = "0.17.6"
 serde_json = "1.0.91"
-rten = { version = "0.4.0" }
+rten = { version = "0.5.0" }
 rten-imageproc = { version = "0.4.0" }
 rten-tensor = { version = "0.4.0" }
 ocrs = { path = "../ocrs", version = "0.5.0" }

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/robertknight/ocrs"
 [dependencies]
 anyhow = "1.0.80"
 rayon = "1.7.0"
-rten = { version = "0.4.0" }
+rten = { version = "0.5.0" }
 rten-imageproc = { version = "0.4.0" }
 rten-tensor = { version = "0.4.0" }
 


### PR DESCRIPTION
Amongst other changes, this includes an update to `rten::Model` which makes it usable in a PyO3 class.