### PR TITLE
Add `--text-mask` flag to CLI tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
-      run: which wasm-bindgen || cargo install wasm-bindgen-cli
+      run: cargo install wasm-bindgen-cli --version 0.2.87
     - name: Build
       run: cargo build
     - name: WASM build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
-      run: cargo install wasm-bindgen-cli --version 0.2.87
+      run: cargo install wasm-bindgen-cli --version 0.2.89
     - name: Build
       run: cargo build
     - name: WASM build

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -16,6 +16,8 @@ rten-imageproc = { version = "0.4.0" }
 rten-tensor = { version = "0.4.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# nb. When changing this, make sure the version of wasm-bindgen-cli installed
+# in CI etc. is in sync.
 wasm-bindgen = "0.2.87"
 
 [dev-dependencies]

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -18,7 +18,7 @@ rten-tensor = { version = "0.4.0" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # nb. When changing this, make sure the version of wasm-bindgen-cli installed
 # in CI etc. is in sync.
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2.89"
 
 [dev-dependencies]
 fastrand = "1.9.0"

--- a/ocrs/src/detection.rs
+++ b/ocrs/src/detection.rs
@@ -7,6 +7,7 @@ use rten_tensor::{NdTensor, NdTensorView, Tensor};
 use crate::preprocess::BLACK_VALUE;
 
 /// Parameters that control post-processing of text detection model outputs.
+#[derive(Clone, Debug, PartialEq)]
 pub struct TextDetectorParams {
     /// Threshold for minimum area of returned rectangles.
     ///
@@ -87,6 +88,12 @@ impl TextDetector {
             params,
             input_shape,
         })
+    }
+
+    /// Return the confidence threshold used to determine whether a pixel is
+    /// text or not.
+    pub fn threshold(&self) -> f32 {
+        self.params.text_threshold
     }
 
     /// Detect text words in a greyscale image.

--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -19,7 +19,7 @@ mod text_items;
 #[cfg(target_arch = "wasm32")]
 mod wasm_api;
 
-use detection::TextDetector;
+use detection::{TextDetector, TextDetectorParams};
 use layout_analysis::find_text_lines;
 use preprocess::prepare_image;
 use recognition::{RecognitionOpt, TextRecognizer};
@@ -177,6 +177,15 @@ impl OcrEngine {
         };
         let line_image = recognizer.prepare_input(input.image.view(), line);
         Ok(line_image)
+    }
+
+    /// Return the confidence threshold applied to the output of the text
+    /// detection model to determine whether a pixel is text or not.
+    pub fn detection_threshold(&self) -> f32 {
+        self.detector
+            .as_ref()
+            .map(|detector| detector.threshold())
+            .unwrap_or(TextDetectorParams::default().text_threshold)
     }
 
     /// Convenience API that extracts all text from an image as a single string.


### PR DESCRIPTION
This saves the binarized version of the text probability map as a PNG file. This
is useful to see where detections were above/below the current confidence
threshold.

Input image:

<img width="512" alt="why-rust" src="https://github.com/robertknight/ocrs/assets/2458/788eeb0b-ecec-4914-be64-7382b37db544">

Probability map (`text-map.png`, generated by `--text-map`):

<img width="512" src="https://github.com/robertknight/ocrs/assets/2458/c3386f7b-58e2-4423-9efb-52a013fbc921">

Binary mask (`text-mask.png`, generated by `--text-mask`):

<img width="512" src="https://github.com/robertknight/ocrs/assets/2458/ce12dffc-2b08-46f1-b7e8-6475184f76ce">


