### PR TITLE
Disable doc generation for ocrs CLI tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,7 @@ jobs:
       run: |
         make checkformatting
         make lint
+    - name: Docs
+      run: make doc
     - name: E2E Test
       run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ check: checkformatting test lint
 checkformatting:
 	cargo fmt --check
 
+.PHONY: docs
+doc:
+	cargo doc
+
 .PHONY: lint
 lint:
 	cargo clippy --workspace

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -25,3 +25,7 @@ anyhow = "1.0.79"
 [[bin]]
 name = "ocrs"
 path = "src/main.rs"
+
+# Disable documentation for ocrs binary to avoid a filename conflict in
+# `target/doc/` with docs for the ocrs library crate.
+doc = false


### PR DESCRIPTION
When running `cargo doc` the docs for the `ocrs` binary would end up overwriting the docs for the `ocrs` library crate in `target/doc/ocrs`. Only the docs for the library crate are actually useful, so disable doc generation for the binary using `doc = false`. This follows suggestions in https://github.com/rust-lang/cargo/issues/6313.

Also generate docs in CI.