### PR TITLE
Improve hello_ocr example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ checkformatting:
 doc:
 	cargo doc
 
+.PHONY: run-example
+example:
+	cd ocrs/examples && ./download-models.sh
+	cargo run -p ocrs --release --example hello_ocr ocrs/examples/rust-book.jpg
+
 .PHONY: lint
 lint:
 	cargo clippy --workspace

--- a/ocrs/examples/hello_ocr.rs
+++ b/ocrs/examples/hello_ocr.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 use std::error::Error;
 use std::fs;
+use std::path::PathBuf;
 
 use ocrs::{OcrEngine, OcrEngineParams};
 use rten::Model;
@@ -36,12 +37,19 @@ fn parse_args() -> Result<Args, lexopt::Error> {
     Ok(Args { image })
 }
 
+/// Read a file from a path that is relative to the crate root.
+fn read_file(path: &str) -> Result<Vec<u8>, std::io::Error> {
+    let mut abs_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    abs_path.push(path);
+    fs::read(abs_path)
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
 
     // Use the `download-models.sh` script to download the models.
-    let detection_model_data = fs::read("text-detection.rten")?;
-    let rec_model_data = fs::read("text-recognition.rten")?;
+    let detection_model_data = read_file("examples/text-detection.rten")?;
+    let rec_model_data = read_file("examples/text-recognition.rten")?;
 
     let detection_model = Model::load(&detection_model_data)?;
     let recognition_model = Model::load(&rec_model_data)?;
@@ -60,13 +68,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     // to greyscale, map range to [-0.5, 0.5]).
     let ocr_input = engine.prepare_input(image.view())?;
 
-    // Phase 1: Detect text words
+    // Detect and recognize text. If you only need the text and don't need any
+    // layout information, you can also use `engine.get_text(&ocr_input)`,
+    // which returns all the text in an image as a single string.
+
+    // Get oriented bounding boxes of text words in input image.
     let word_rects = engine.detect_words(&ocr_input)?;
 
-    // Phase 2: Perform layout analysis
+    // Group words into lines. Each line is represented by a list of word
+    // bounding boxes.
     let line_rects = engine.find_text_lines(&ocr_input, &word_rects);
 
-    // Phase 3: Recognize text
+    // Recognize the characters in each line.
     let line_texts = engine.recognize_text(&ocr_input, &line_rects)?;
 
     for line in line_texts


### PR DESCRIPTION
 - Improve some comments about what the steps in the example are doing, and also mention the `OcrEngine::get_text` API.

 - Allow the "hello world" example to be run from any directory, by locating models relative to the crate root instead of the current working directory.

 - Add `make example` to simplify running the example in development.