### PR TITLE
Change package name to avoid name similarity issue

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ocrs",
+  "name": "@robertknight/ocrs",
   "version": "0.1.0",
   "description": "Ocrs is a library for extracting text from images",
   "type": "module",


### PR DESCRIPTION
npm refuses to publish the package under the name `ocrs` due to similarity to the existing package name `cors`. Take npm's suggestion and scope it under my username.