### PR TITLE
Add `avx512` feature

### DIFF
--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -22,6 +22,10 @@ url = "2.4.0"
 home = "0.5.9"
 anyhow = "1.0.79"
 
+[features]
+# Use AVX-512 instructions if available. Requires nightly Rust.
+avx512 = ["rten/avx512"]
+
 [[bin]]
 name = "ocrs"
 path = "src/main.rs"

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -27,3 +27,7 @@ rten-imageio = { version = "0.8.0" }
 
 [lib]
 crate-type = ["lib", "cdylib"]
+
+[features]
+# Use AVX-512 instructions if available. Requires nightly Rust.
+avx512 = ["rten/avx512"]


### PR DESCRIPTION
This enables the AVX-512 kernels in RTen.

The performance impact on my system is modest (around ~7%). It would be bigger on the server if https://github.com/robertknight/rten/issues/17 was solved.