### PR TITLE
Avoid unnecessary copies when preparing detection inputs

### DIFF
--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -11,6 +11,8 @@ mod log;
 mod preprocess;
 mod recognition;
 
+mod tensor_util;
+
 #[cfg(test)]
 mod test_util;
 

--- a/ocrs/src/tensor_util.rs
+++ b/ocrs/src/tensor_util.rs
@@ -1,0 +1,37 @@
+use std::borrow::Cow;
+
+use rten_tensor::prelude::*;
+use rten_tensor::{MutLayout, TensorBase};
+
+/// Convert an owned tensor or view into one which uses a [Cow] for storage.
+///
+/// This is useful for code that wants to conditionally copy a tensor, as this
+/// trait can be used to convert either an owned copy or view to the same type.
+pub trait IntoCow {
+    type Cow;
+
+    fn into_cow(self) -> Self::Cow;
+}
+
+impl<'a, T, L: MutLayout> IntoCow for TensorBase<T, &'a [T], L>
+where
+    [T]: ToOwned,
+{
+    type Cow = TensorBase<T, Cow<'a, [T]>, L>;
+
+    fn into_cow(self) -> Self::Cow {
+        TensorBase::from_data(self.shape(), Cow::Borrowed(self.non_contiguous_data()))
+    }
+}
+
+impl<T: Clone + 'static, L: MutLayout> IntoCow for TensorBase<T, Vec<T>, L>
+where
+    [T]: ToOwned<Owned = Vec<T>>,
+{
+    type Cow = TensorBase<T, Cow<'static, [T]>, L>;
+
+    fn into_cow(self) -> Self::Cow {
+        let layout = self.layout().clone();
+        TensorBase::from_data(layout.shape(), Cow::Owned(self.into_data()))
+    }
+}


### PR DESCRIPTION
Remove a copy that is sometimes redundant:

 - If the image doesn't need to be padded, don't copy it
 - If the image doesn't need to be resized, don't do an identity resize

For small inputs where both spatial dimensions are smaller than the model's
input we'll need to pad but not resize. For large inputs where the opposite is
true we'll need to resize but not pad. For medium inputs where one dim exceeds
the corresponding model input size and the other is smaller, we'll need to do
both.
