### PR TITLE
Skip WebAssembly on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Setup rust
       run: rustup target add wasm32-unknown-unknown
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -26,10 +27,12 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
       run: cargo install wasm-bindgen-cli --version 0.2.89
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build
       run: cargo build
     - name: WASM build
       run: make wasm
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Test
       run: make test
     - name: Lint


### PR DESCRIPTION
The Windows CI build is much slower than Linux. We only need to build and test wasm on one host platform, so do it on Linux. This change was made in the RTen repository previously.