### PR TITLE
Propagate errors running recognition model, instead of panicking

### DIFF
--- a/ocrs/src/errors.rs
+++ b/ocrs/src/errors.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+use std::fmt;
+
+/// The error type returned when running a machine learning model fails.
+#[derive(Debug)]
+pub enum ModelRunError {
+    /// Model execution failed.
+    RunFailed(Box<dyn Error + Send + Sync>),
+
+    /// The model output had a different data type or shape than expected.
+    WrongOutput,
+}
+
+impl fmt::Display for ModelRunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            ModelRunError::RunFailed(err) => write!(f, "model run failed: {}", err),
+            ModelRunError::WrongOutput => {
+                write!(f, "model output had unexpected type or shape")
+            }
+        }
+    }
+}
+
+impl Error for ModelRunError {}

--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -5,6 +5,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
 
 mod detection;
+mod errors;
 mod geom_util;
 mod layout_analysis;
 mod log;


### PR DESCRIPTION
Complete an old TODO to propagate errors when executing the recognition model.