### PR TITLE
Support building CLI for wasm32-wasi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,12 @@ wasm:
 	wasm-bindgen target/wasm32-unknown-unknown/release/ocrs.wasm --out-dir js/dist/ --target web --reference-types --weak-refs
 	tools/optimize-wasm.sh js/dist/ocrs_bg.wasm
 
+# Build Ocrs CLI for non-browser WebAssembly runtimes (eg. wasmtime). Run using:
+#
+#	wasmtime --dir . target/wasm32-wasi/release/ocrs.wasm --detect-model text-detection.rten --rec-model text-recognition.rten ocrs-cli/test-data/why-rust.png
+.PHONY: wasm-wasi
+wasm-wasi:
+	RUSTFLAGS="-C target-feature=+simd128" cargo build --release --target wasm32-wasi --package ocrs-cli
+
 .PHONY: wasm-all
 wasm-all: wasm wasm-nosimd

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -17,10 +17,12 @@ rten-imageproc = { version = "0.9.0" }
 rten-tensor = { version = "0.9.0" }
 ocrs = { path = "../ocrs", version = "0.7.0" }
 lexopt = "0.3.0"
-ureq = "2.9.7"
 url = "2.4.0"
-home = "0.5.9"
 anyhow = "1.0.79"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ureq = "2.9.7"
+home = "0.5.9"
 
 [features]
 # Use AVX-512 instructions if available. Requires nightly Rust.

--- a/ocrs-cli/src/models.rs
+++ b/ocrs-cli/src/models.rs
@@ -1,13 +1,18 @@
 use std::fmt;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::{fs, path::Path};
 
 use anyhow::anyhow;
 use rten::Model;
+
+#[cfg(not(target_arch = "wasm32"))]
 use url::Url;
 
 /// Return the path to the directory in which cached models etc. should be
 /// saved.
+#[cfg(not(target_arch = "wasm32"))]
 fn cache_dir() -> Result<PathBuf, anyhow::Error> {
     let mut cache_dir: PathBuf =
         home::home_dir().ok_or(anyhow!("Failed to determine home directory"))?;
@@ -22,6 +27,7 @@ fn cache_dir() -> Result<PathBuf, anyhow::Error> {
 /// Extract the last path segment from a URL.
 ///
 /// eg. "https://models.com/text-detection.rten" => "text-detection.rten".
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(rustdoc::bare_urls)]
 fn filename_from_url(url: &str) -> Option<String> {
     let parsed = Url::parse(url).ok()?;
@@ -33,6 +39,7 @@ fn filename_from_url(url: &str) -> Option<String> {
 
 /// Download a file from `url` to a local cache, if not already fetched, and
 /// return the path to the local file.
+#[cfg(not(target_arch = "wasm32"))]
 fn download_file(url: &str, filename: Option<&str>) -> Result<PathBuf, anyhow::Error> {
     let cache_dir = cache_dir()?;
     let filename = match filename {
@@ -53,6 +60,13 @@ fn download_file(url: &str, filename: Option<&str>) -> Result<PathBuf, anyhow::E
     fs::write(&file_path, &body)?;
 
     Ok(file_path)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn download_file(_url: &str, _filename: Option<&str>) -> Result<PathBuf, anyhow::Error> {
+    Err(anyhow!(
+        "Downloading models from a URL is not supported on the current platform"
+    ))
 }
 
 /// Location that a model can be loaded from.


### PR DESCRIPTION
This provides a more convenient way to test a WebAssembly build of the library compared to the Node demo, with the downside that it isn't the same runtme. Performance seems roughly comparable though.

When running the wasm32-wasi build, models must be loaded from the filesystem, as the infrastructure to download from an HTTPS URL is missing in this platform.