### PR TITLE
Bump rten v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +269,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -378,13 +394,15 @@ dependencies = [
 
 [[package]]
 name = "rten"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9d6d80601e57cab46f477955be6e3be1a4c92ed0aebb3376e1f19d24e83bb1"
+checksum = "09c030cdf90e64c5eeeba389ca59da14b0a106b1b8366c15591251bb6a2e777f"
 dependencies = [
  "flatbuffers",
  "libm",
+ "num_cpus",
  "rayon",
+ "rten-simd",
  "rten-tensor",
  "rten-vecmath",
  "rustc-hash",
@@ -394,27 +412,36 @@ dependencies = [
 
 [[package]]
 name = "rten-imageproc"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529fdef25f8232ebb08fb6cfc785ec97a7fb268bebc4895e36e8750e2bbeaa51"
+checksum = "5ba61077269b2b2c90445bfd55fb798dcd544b56e7fd78faaea51940b8e429ae"
 dependencies = [
  "rten-tensor",
 ]
 
 [[package]]
-name = "rten-tensor"
-version = "0.9.0"
+name = "rten-simd"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa78180a98337a43163e9da8f202120e9ae3b82366cccfb05a5a854e48cd581"
+checksum = "8eb16da64e0d08ce56dc17d8304ab2da541176ee30430c0b0e581a7841a660ae"
+
+[[package]]
+name = "rten-tensor"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5e53d2e43bb736e89e4ea41b707e024190f8ba47c3eddf5a3c2d022089909"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "rten-vecmath"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495f48d459768d61ca37b418f79ac7aac3a707024c79fa49a14dd2c1ad8a2c0e"
+checksum = "56eccc46a7e7a2df2cebb7ba95e613a01942a01e0f2f2f7d6122176ab7372e9f"
+dependencies = [
+ "rten-simd",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ members = [
   "ocrs",
   "ocrs-cli",
 ]
+
+[workspace.dependencies]
+rten = { version = "0.10.0" }
+rten-imageproc = { version = "0.10.0" }
+rten-tensor = { version = "0.10.0" }

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/robertknight/ocrs"
 image = { version = "0.25.1", default-features = false, features = ["png", "jpeg", "webp"] }
 png = "0.17.6"
 serde_json = "1.0.116"
-rten = { version = "0.9.0" }
-rten-imageproc = { version = "0.9.0" }
-rten-tensor = { version = "0.9.0" }
+rten = { workspace = true }
+rten-imageproc = { workspace = true }
+rten-tensor = { workspace = true }
 ocrs = { path = "../ocrs", version = "0.7.0" }
 lexopt = "0.3.0"
 url = "2.4.0"

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/robertknight/ocrs"
 [dependencies]
 anyhow = "1.0.80"
 rayon = "1.10.0"
-rten = { version = "0.9.0" }
-rten-imageproc = { version = "0.9.0" }
-rten-tensor = { version = "0.9.0" }
+rten = { workspace = true }
+rten-imageproc = { workspace = true }
+rten-tensor = { workspace = true }
 thiserror = "1.0.59"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
The changes include significant performance improvements for the `GRU` operator, which makes recognition of long text lines faster, as well as adapting the thread pool size to the number of physical rather than logical cores, reducing overhead on systems with SMT / hyperthreading.

To adapt to the thread pool changes, `rten::thread_pool().run(...)` is now used to run line recognition preprocessing in the same thread pool that is used to execute the recognition model. This avoids contention from having more threads than cores.

**Benchmarks:**

Testing with the `polar-bears.png` example on an Ice Lake Intel i5:

```
cargo build -r -p ocrs-cli
time target/release/ocrs ocrs-cli/test-data/polar-bears.png
```

Before: ~1.00s
After: ~570ms

In contrast with the `why-rust.png` example, which has a larger image but shorter lines, the impact is smaller:

Before: ~916ms
After: ~790ms