### PR TITLE
Replace broken `round_up` with `u32::next_multiple_of`

### DIFF
--- a/ocrs-cli/test-data/polar-bears.expected.txt
+++ b/ocrs-cli/test-data/polar-bears.expected.txt
@@ -1,5 +1,5 @@
 Fossils of polar bears are uncommon. [12][15] The oldest known fossil is a 130.000- to 110,000-year-old jaw bone, found on Prince Charles Foreland,
-Norway, in 2004,120)[1) Scientists in the 20th century surmised that polar bears directly descended from a population of brown bears, possibly in eastern
+Norway, in 2004,120)[1) Scientists in the 20th century surmised that polar bears directly descended from  population of brown bears, possibly in eastern
 Siberia or Alaska.[12][15] Mitochondrial DNA studies in the 1990s and 2000s supported the status of the polar bear as a derivative of the brown bear.
 finding that some brown bear populations were more closely related to polar bears than to other brown bears, particularly the ABC Islands bears of
-Southeast Alaska.[20][21]22] A 2010 study estimated that the polar bear lineage split from other brown bears around 150,000 years ago./20]
+Southeast Alaska.[20][21][22] A 2010 study estimated that the polar bear lineage split from other brown bears around 150,000 years ago./20;

--- a/ocrs/src/recognition.rs
+++ b/ocrs/src/recognition.rs
@@ -15,20 +15,6 @@ use crate::geom_util::{downwards_line, leftmost_edge, rightmost_edge};
 use crate::preprocess::BLACK_VALUE;
 use crate::text_items::{TextChar, TextLine};
 
-/// Return the smallest multiple of `factor` that is >= `val`.
-fn round_up<
-    T: Copy
-        + std::ops::Add<T, Output = T>
-        + std::ops::Sub<T, Output = T>
-        + std::ops::Rem<T, Output = T>,
->(
-    val: T,
-    factor: T,
-) -> T {
-    let rem = val % factor;
-    (val + factor) - rem
-}
-
 /// Return a polygon which contains all the rects in `words`.
 ///
 /// `words` is assumed to be a series of disjoint rectangles ordered from left
@@ -454,7 +440,7 @@ impl TextRecognizer {
                 .integral_bounding_rect();
             let resized_width =
                 resized_line_width(line_rect.width(), line_rect.height(), rec_img_height as i32);
-            let group_width = round_up(resized_width, 50);
+            let group_width = resized_width.next_multiple_of(50);
             line_groups
                 .entry(group_width as i32)
                 .or_default()


### PR DESCRIPTION
The output of `round_up` was `val + factor` instead of `val` when `val` was an exact multiple of factor. Use the standard library method instead which handles this case correctly. This change resulted in a small change to one of the E2E test outputs.