### PR TITLE
Elide lifetimes in impls where possible

### DIFF
--- a/ocrs-cli/src/models.rs
+++ b/ocrs-cli/src/models.rs
@@ -79,7 +79,7 @@ pub enum ModelSource<'a> {
     Path(&'a str),
 }
 
-impl<'a> fmt::Display for ModelSource<'a> {
+impl fmt::Display for ModelSource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/ocrs/src/preprocess.rs
+++ b/ocrs/src/preprocess.rs
@@ -25,7 +25,7 @@ impl<'a> From<NdTensorView<'a, u8, 3>> for ImagePixels<'a> {
     }
 }
 
-impl<'a> ImagePixels<'a> {
+impl ImagePixels<'_> {
     fn shape(&self) -> [usize; 3] {
         match self {
             ImagePixels::Floats(f) => f.shape(),

--- a/ocrs/src/text_items.rs
+++ b/ocrs/src/text_items.rs
@@ -94,19 +94,19 @@ pub struct TextWord<'a> {
 }
 
 impl<'a> TextWord<'a> {
-    fn new(chars: &'a [TextChar]) -> TextWord {
+    fn new(chars: &'a [TextChar]) -> TextWord<'a> {
         assert!(!chars.is_empty(), "Text words must not be empty");
         TextWord { chars }
     }
 }
 
-impl<'a> TextItem for TextWord<'a> {
+impl TextItem for TextWord<'_> {
     fn chars(&self) -> &[TextChar] {
         self.chars
     }
 }
 
-impl<'a> fmt::Display for TextWord<'a> {
+impl fmt::Display for TextWord<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt_text_item(self, f)
     }


### PR DESCRIPTION
Resolve `clippy::needless_lifetimes` lint warnings.