### PR TITLE
Add a public `from_tensor` builder to `OcrInput`

### DIFF
--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -91,6 +91,11 @@ pub struct OcrInput {
     /// CHW tensor with normalized pixel values in [BLACK_VALUE, BLACK_VALUE + 1.].
     pub(crate) image: NdTensor<f32, 3>,
 }
+impl OcrInput {
+    pub fn from_tensor(tensor: NdTensor<f32, 3>) -> Self {
+        Self { image: tensor }
+    }
+}
 
 impl OcrEngine {
     /// Construct a new engine from a given configuration.


### PR DESCRIPTION
Thank you for the library,

I have a situation where I want to prepare the image (as in `prepare_image`) from a custom data source that is not backed by an `ImageSource` or `NdTensorView` . But currently, the only way to prepare the input/create an `OcrInput` is from an  `ImageSource` via ``prepare_input`.

This PR adds a `from_tensor` builder to `OcrInput ` which allows to have a custom `prepare` step to build a tensor, and then transform it to an `OcrInput`.


