### PR TITLE
Bump rten to v0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
-      run: cargo install wasm-bindgen-cli --version 0.2.93
+      run: cargo install wasm-bindgen-cli --version 0.2.100
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build
       run: cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "rten"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c949933c1227e10b0a6ee4e348f47f9715a667804648040872dc0e8cecba4e"
+checksum = "98149187c9143636c9890588b2332265f945f07c0e1f441324fb9a79e30a1cb0"
 dependencies = [
  "flatbuffers",
  "num_cpus",
@@ -432,33 +432,33 @@ dependencies = [
 
 [[package]]
 name = "rten-imageproc"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa140b1c0f2c82f04b87ae637ef86d04cc04b8ea7c834c63c74464699d76c7b3"
+checksum = "2a9230c3493521ee90a84c597e0b80ad1bcb40d3bd22b7c830c578921469beb0"
 dependencies = [
  "rten-tensor",
 ]
 
 [[package]]
 name = "rten-simd"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b90ce15adb254df4887e113ec9114722b9d948f3fb0aeb3722dc141bad085"
+checksum = "a17e91b7a5de96d4e9ce6667380fd9f20c09154e9b18d4baa594b3d56528e396"
 
 [[package]]
 name = "rten-tensor"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6d026e4576b49c6cebbfd26c09d494452820d5794e57583d604f657b146595"
+checksum = "fbc2f6f94db1a2bb4ef8e165698cd610e35d369fd04b5d63271ecc3d63ac3f7f"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "rten-vecmath"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b929b6ab9102ecfb7bec50ca5ed7cb5613635cbbb641ea4098737b9ad9826d"
+checksum = "b135ba1b4bcf84bcf78a8e681e3e41ab23e39fccd92dfdfc61144a8ba0326361"
 dependencies = [
  "rten-simd",
 ]
@@ -509,6 +509,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -695,24 +701,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -721,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -731,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -744,9 +750,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ members = [
 ]
 
 [workspace.dependencies]
-rten = { version = "0.15.0" }
-rten-imageproc = { version = "0.15.0" }
-rten-tensor = { version = "0.15.0" }
+rten = { version = ">= 0.14.0, < 0.17.0" }
+rten-imageproc = { version = ">= 0.14.0, < 0.17.0" }
+rten-tensor = { version = ">= 0.14.0, < 0.17.0" }


### PR DESCRIPTION
This release adds support for quantized models, although no quantized versions of the Ocrs default models are available yet.

The rten version ranges are set to ">= 0.14.0, < 0.17.0" since ocrs will build with v0.14.0 or later. There are small semver incompatible changes in the later releases, but they don't affect this library.