### PR TITLE
Recommend use of `--locked` when installing ocrs-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To install the CLI tool, you will first need Rust and Cargo installed. Then
 run:
 
 ```sh
-$ cargo install ocrs-cli
+$ cargo install ocrs-cli --locked
 ```
 
 ## CLI usage


### PR DESCRIPTION
I was surprised to learn that `cargo install` does not respect a binary package's lockfile by default [^1] and will attempt to upgrade dependencies. Aside from installing package combinations that haven't been directly tested, this also undoes the change in [^2] to avoid installing Unicode-related dependencies. Specifying `--locked` when installing is thus both safer and faster.

[^1]: https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile
[^2]: https://github.com/robertknight/ocrs/pull/163