### PR TITLE
Fix `mismatched_lifetime_syntaxes` lint warning

### DIFF
--- a/ocrs/src/text_items.rs
+++ b/ocrs/src/text_items.rs
@@ -73,7 +73,7 @@ impl TextLine {
     }
 
     /// Return an iterator over words in this line.
-    pub fn words(&self) -> impl Iterator<Item = TextWord> {
+    pub fn words(&self) -> impl Iterator<Item = TextWord<'_>> {
         self.chars()
             .split(|c| c.char == ' ')
             .filter(|chars| !chars.is_empty())


### PR DESCRIPTION
Fix a lint warning during compile when using Rust v1.89 or later.