### PR TITLE
Remove usage of model_builder feature from rten dep

### DIFF
--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -25,7 +25,7 @@ wasm-bindgen = "0.2.93"
 fastrand = "2.3.0"
 image = { version = "0.25.8", default-features = false, features = ["png", "jpeg", "webp"] }
 lexopt = "0.3.1"
-rten = { workspace = true, features = ["model_builder"] }
+rten = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
Following https://github.com/robertknight/ocrs/pull/205 this is no longer needed.