### PR TITLE
Enable loading models in ONNX format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Updated to rten v0.24. This adds the ability to load custom models in
+  ONNX format instead of `.rten` format (requires enabling the `onnx` crate feature)
+
 ## [0.11.0] - 2025-09-11
 
 - Updated to rten v0.22. This enables AVX-512 on stable Rust and updates the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "rten-base",
  "rten-gemm",
  "rten-model-file",
+ "rten-onnx",
  "rten-shape-inference",
  "rten-simd",
  "rten-tensor",
@@ -515,6 +516,12 @@ dependencies = [
  "flatbuffers",
  "rten-base",
 ]
+
+[[package]]
+name = "rten-onnx"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23086eef75bfb55278cb0b45cf9f5a877d466d914914aafebee4ffca9b24d20c"
 
 [[package]]
 name = "rten-shape-inference"

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -20,6 +20,10 @@ lexopt = "0.3.1"
 url = "2.5.4"
 anyhow = "1.0.99"
 
+[features]
+# Support loading custom models in ONNX format
+onnx = ["ocrs/onnx"]
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "3.1.2"
 home = "0.5.11"

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -27,5 +27,9 @@ image = { version = "0.25.9", default-features = false, features = ["png", "jpeg
 lexopt = "0.3.1"
 rten = { workspace = true }
 
+[features]
+# Enables loading custom models in ONNX format
+onnx = ["rten/onnx_format"]
+
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
RTen v0.23 added the ability to load models in .onnx format directly, skipping the conversion to .rten format. Expose this in the ocrs crate via an `onnx` feature.