### PR TITLE
Fix WebAssembly build

### DIFF
--- a/ocrs/src/wasm_api.rs
+++ b/ocrs/src/wasm_api.rs
@@ -52,7 +52,7 @@ impl OcrEngineInit {
             Sigmoid,
             Slice,
             Transpose,
-            Squeeze
+            Unsqueeze
         )
     }
 


### PR DESCRIPTION
Fix a regression introduced in 75733b673e0dc42afa4e854af18ad02498ff1877 where the list of enabled operators was incorrectly ported to the new API, replacing `Unsqueeze` with `Squeeze`.

Fixes https://github.com/robertknight/ocrs/issues/227

---

**Testing:**

```
make wasm
cd js/examples/ocr-node
node index.js ~/.cache/ocrs/text-detection.rten ~/.cache/ocrs/text-recognition.rten ../../../ocrs/examples/rust-book.jpg
```

This assumes you've run the `ocrs` CLI to populate `~/.cache`.