### PR TITLE
Move wasm API and rten format behind features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ members = [
 ]
 
 [workspace.dependencies]
-rten = { version = "0.24.0", default-features = false, features = ["rten_format"] }
+rten = { version = "0.24.0", default-features = false }
 rten-imageproc = { version = "0.24.0" }
 rten-tensor = { version = "0.24.0" }

--- a/ocrs-cli/Cargo.toml
+++ b/ocrs-cli/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0.149"
 rten = { workspace = true }
 rten-imageproc = { workspace = true }
 rten-tensor = { workspace = true }
-ocrs = { path = "../ocrs", version = "0.12.2" }
+ocrs = { path = "../ocrs", version = "0.12.2", features = ["rten"] }
 lexopt = "0.3.2"
 url = "2.5.4"
 anyhow = "1.0.102"

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -28,8 +28,13 @@ lexopt = "0.3.2"
 rten = { workspace = true }
 
 [features]
+default = ["export-wasm", "rten"]
+# Enables wasm API (i.e. exposes ocrs API to JS)
+export-wasm = []
 # Enables loading custom models in ONNX format
 onnx = ["rten/onnx_format"]
+# Enables loading custom models in rten format
+rten = ["rten/rten_format"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/ocrs/src/lib.rs
+++ b/ocrs/src/lib.rs
@@ -17,7 +17,7 @@ mod test_util;
 
 mod text_items;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "export-wasm", target_arch = "wasm32"))]
 mod wasm_api;
 
 use detection::{TextDetector, TextDetectorParams};


### PR DESCRIPTION
This change allows disabling the wasm API and rten format to reduce binary size.

Disabling wasm API reduces my wasm binary by about 100kb.  Disabling rten format (i.e. using only onnx) reduces my wasm binary by about 150kb. (i.e. ~250kb total in my case)

See also: #239