### PR TITLE
Build with clipboard feature enabled in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       run: cargo install wasm-bindgen-cli --version 0.2.100
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build
-      run: cargo build
+      run: cargo build --features clipboard
     - name: WASM build
       run: make wasm
       if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
I realized that CI was building the CLI without clipboard support enabled when inspecting the CI logs for https://github.com/robertknight/ocrs/pull/255.