### PR TITLE
Add an AI policy to the project

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,38 @@
+# AI Policy
+
+Using AI (i.e., LLMs) as tools for coding is welcome. A high bar is held for
+all contributions to this project. Moreover, the project maintainers remain
+responsible for any code that is published as part of a release. Contributors
+are expected to be responsible for any code they publish.
+
+**AI should not be used to generate comments when communicating with
+maintainers**. Comments are expected to be written by humans. Comments that are
+believed to be written by AI may be hidden without notice.
+
+If you are opening an issue, you should be able to describe the problem in your
+own words.
+
+If you are opening a pull request, you are expected to be able to explain the
+proposed changes in your own words. This includes the pull request body and
+responses to questions. **Do not copy responses from the AI when replying to
+questions from maintainers.**
+
+This project requires a human in the loop who understands the work produced
+by AI. **Autonomous agents are not allowed to be used for contributing to this
+project**. Pull requests that appear in violation of this will be closed,
+perhaps without notice.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) or `<details>` block and disclosed as
+such. It must be accompanied by human commentary explaining the relevance and
+implications of the context. Do not share long snippets.
+
+AI is useful when communicating as a non-native English speaker. If you are
+using AI to edit your comments for this purpose, please take the time to ensure
+it reflects your own voice and ideas. If using AI for translation, we recommend
+writing in your native language and including the AI translation in a quote
+block.
+
+This policy was adapted from the [regex crate's AI policy].
+
+[regex crate's AI policy]: https://github.com/rust-lang/regex/blob/72d650cb0a880a01ab6dc2137c0888e8f89740f7/AI_POLICY.md


### PR DESCRIPTION
Add a policy copied from [rten](https://github.com/robertknight/rten), which in turn is based on uv's policy.

This allows the use of AI when writing code but disallows it when communicating with maintainers in issues and PRs. Contributors are expected to fully understand any AI-generated code and ensure it meets the same standards of correctness and maintainability as if they wrote it by hand.