### PR TITLE
Use ONNX-format versions of detection and recognition models

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,8 +43,8 @@ test:
 # Run ocrs-capi integration tests (full OCR pipeline through the C ABI).
 test-capi:
     cd ocrs/examples && ./download-models.sh
-    OCRS_DETECTION_MODEL={{justfile_directory()}}/ocrs/examples/text-detection.rten \
-    OCRS_RECOGNITION_MODEL={{justfile_directory()}}/ocrs/examples/text-recognition.rten \
+    OCRS_DETECTION_MODEL={{justfile_directory()}}/ocrs/examples/text-detection.onnx \
+    OCRS_RECOGNITION_MODEL={{justfile_directory()}}/ocrs/examples/text-recognition.onnx \
     cargo test -p ocrs-capi --release --test ocr -- --ignored
 
 # Run end-to-end tests against the CLI.
@@ -63,7 +63,7 @@ wasm:
 
 # Run the result using:
 #
-#   wasmtime --dir . target/wasm32-wasi/release/ocrs.wasm --detect-model text-detection.rten --rec-model text-recognition.rten ocrs-cli/test-data/why-rust.png
+#   wasmtime --dir . target/wasm32-wasi/release/ocrs.wasm --detect-model text-detection.onnx --rec-model text-recognition.onnx ocrs-cli/test-data/why-rust.png
 
 # Build Ocrs CLI for non-browser WebAssembly runtimes (eg. wasmtime).
 wasm-wasi:

--- a/ocrs-capi/README.md
+++ b/ocrs-capi/README.md
@@ -80,8 +80,8 @@ recognizes text in an image.
 1. Download the models:
 
 ```sh
-curl -O https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.rten
-curl -O https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.rten
+curl -O https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.onnx
+curl -O https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.onnx
 ```
 
 2. Produce raw pixels from any image (here using Python + Pillow). Update the
@@ -110,7 +110,7 @@ zig build-exe examples/zig/main.zig -I include \
 
 4. Run the example
 
-Run `./main` from the directory containing the `.rten` files and `image.rgb`.
+Run `./main` from the directory containing the `.onnx` files and `image.rgb`.
 
 (The same `libocrs_capi.a` plus `include/ocrs.h` can be wired into a `build.zig`
 with `exe.addObjectFile`, `exe.addIncludePath` and `exe.linkLibC()`.)

--- a/ocrs-capi/examples/zig/main.zig
+++ b/ocrs-capi/examples/zig/main.zig
@@ -4,8 +4,8 @@
 //! raw pixel data are hardcoded. Makes the example simpler instead of going
 //! through Zig Io for the sake of the example.
 //!
-//! See `README.md` for how to produce `text-detection.rten`,
-//! `text-recognition.rten` and the raw `image.rgb` referenced below, and for
+//! See `README.md` for how to produce `text-detection.onnx`,
+//! `text-recognition.onnx` and the raw `image.rgb` referenced below, and for
 //! the exact `zig build-exe` command used to link against `libocrs_capi`.
 
 const std = @import("std");
@@ -14,8 +14,8 @@ const c = @cImport({
 });
 
 // Paths to the model files, relative to the working directory at run time.
-const detection_model = "text-detection.rten";
-const recognition_model = "text-recognition.rten";
+const detection_model = "text-detection.onnx";
+const recognition_model = "text-recognition.onnx";
 
 // Raw 8-bit pixels in row-major, channels-last (HWC) order. Generate this with
 // the Python snippet in README.md and update the dimensions to match.

--- a/ocrs-capi/include/ocrs.h
+++ b/ocrs-capi/include/ocrs.h
@@ -50,9 +50,9 @@ const char *ocrs_last_error(void);
 // Create an engine, loading the detection and recognition models from files.
 //
 // `detection_model_path` and `recognition_model_path` are NUL-terminated paths
-// to `.rten` model files (or `.onnx` if built with the `onnx` feature). Either
-// may be NULL to omit that model, though detection is required for
-// [`ocrs_engine_get_text`] and recognition is required for any text output.
+// to `.onnx` model files. Either may be NULL to omit that model, though
+// detection is required for [`ocrs_engine_get_text`] and recognition is
+// required for any text output.
 //
 // Returns NULL on failure. See [`ocrs_last_error`].
 //

--- a/ocrs-capi/src/lib.rs
+++ b/ocrs-capi/src/lib.rs
@@ -148,9 +148,9 @@ unsafe fn load_model_memory(
 /// Create an engine, loading the detection and recognition models from files.
 ///
 /// `detection_model_path` and `recognition_model_path` are NUL-terminated paths
-/// to `.rten` model files (or `.onnx` if built with the `onnx` feature). Either
-/// may be NULL to omit that model, though detection is required for
-/// [`ocrs_engine_get_text`] and recognition is required for any text output.
+/// to `.onnx` model files. Either may be NULL to omit that model, though
+/// detection is required for [`ocrs_engine_get_text`] and recognition is
+/// required for any text output.
 ///
 /// Returns NULL on failure. See [`ocrs_last_error`].
 ///
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn new_with_bad_path_reports_error() {
-        let path = CString::new("/no/such/model.rten").unwrap();
+        let path = CString::new("/no/such/model.onnx").unwrap();
         let engine = unsafe { ocrs_engine_new(path.as_ptr(), ptr::null()) };
         assert!(engine.is_null());
         let err = last_error().expect("error should be set");

--- a/ocrs-capi/tests/ocr.rs
+++ b/ocrs-capi/tests/ocr.rs
@@ -3,8 +3,8 @@
 //!
 //! Read the model paths from environment variables:
 //!
-//!   OCRS_DETECTION_MODEL   = path to text-detection.rten
-//!   OCRS_RECOGNITION_MODEL = path to text-recognition.rten
+//!   OCRS_DETECTION_MODEL   = path to text-detection.onnx
+//!   OCRS_RECOGNITION_MODEL = path to text-recognition.onnx
 //!
 //! Run them (downloading the models first) with:
 //!

--- a/ocrs-cli/src/main.rs
+++ b/ocrs-cli/src/main.rs
@@ -302,11 +302,11 @@ Advanced options:
 }
 
 /// Default text detection model.
-const DETECTION_MODEL: &str = "https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.rten";
+const DETECTION_MODEL: &str = "https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.onnx";
 
 /// Default text recognition model.
 const RECOGNITION_MODEL: &str =
-    "https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.rten";
+    "https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.onnx";
 
 /// Convert a decoded image into an HWC tensor.
 fn image_to_tensor(image: image::DynamicImage) -> NdTensor<u8, 3> {

--- a/ocrs-cli/src/models.rs
+++ b/ocrs-cli/src/models.rs
@@ -27,7 +27,7 @@ fn cache_dir() -> Result<PathBuf, anyhow::Error> {
 
 /// Extract the last path segment from a URL.
 ///
-/// eg. "https://models.com/text-detection.rten" => "text-detection.rten".
+/// eg. "https://models.com/text-detection.onnx" => "text-detection.onnx".
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(rustdoc::bare_urls)]
 fn filename_from_url(url: &str) -> Option<String> {

--- a/ocrs-extension/README.md
+++ b/ocrs-extension/README.md
@@ -22,7 +22,7 @@ It has currently only been tested in Chrome.
     ```sh
     cargo run -r -p ocrs-cli test-image.jpeg
     mkdir -p models/ocr
-    cp ~/.cache/ocrs/text-detection.rten ~/.cache/ocrs/text-recognition.rten models/ocr
+    cp ~/.cache/ocrs/text-detection.onnx ~/.cache/ocrs/text-recognition.onnx models/ocr
     ```
 
     Where `test-image.jpeg` can be any image you have available.

--- a/ocrs-extension/justfile
+++ b/ocrs-extension/justfile
@@ -3,8 +3,8 @@ build:
     mkdir -p build
     cp ../dist/ocrs.js ../dist/ocrs.d.ts build/
     cp ../dist/ocrs_bg.wasm build/
-    cp ../models/ocr/text-detection.rten build/
-    cp ../models/ocr/text-recognition.rten build/
+    cp ../models/ocr/text-detection.onnx build/
+    cp ../models/ocr/text-recognition.onnx build/
     npm run build
 
 # Remove build outputs.

--- a/ocrs-extension/src/background.ts
+++ b/ocrs-extension/src/background.ts
@@ -25,8 +25,8 @@ async function createOCREngine(): Promise<OcrEngine> {
     const init = async () => {
       const [ocrBin, detectionModel, recognitionModel] = await Promise.all([
         fetch("../build/ocrs_bg.wasm").then((r) => r.arrayBuffer()),
-        fetch("../build/text-detection.rten").then((r) => r.arrayBuffer()),
-        fetch("../build/text-recognition.rten").then((r) => r.arrayBuffer()),
+        fetch("../build/text-detection.onnx").then((r) => r.arrayBuffer()),
+        fetch("../build/text-recognition.onnx").then((r) => r.arrayBuffer()),
       ]);
 
       await initOcrLib(ocrBin);

--- a/ocrs/Cargo.toml
+++ b/ocrs/Cargo.toml
@@ -28,7 +28,7 @@ lexopt = "0.3.2"
 rten = { workspace = true }
 
 [features]
-default = ["export-wasm", "rten"]
+default = ["export-wasm", "rten", "onnx"]
 # Enables wasm API (i.e. exposes ocrs API to JS)
 export-wasm = []
 # Enables loading custom models in ONNX format

--- a/ocrs/README.md
+++ b/ocrs/README.md
@@ -18,7 +18,7 @@ a Rust application.
 ```sh
 cd examples/
 
-# Download models in .rten format.
+# Download models in .onnx format.
 ./download-models.sh
 
 # Run OCR on an image and print the extracted text.

--- a/ocrs/examples/download-models.sh
+++ b/ocrs/examples/download-models.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DETECTION_MODEL="https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.rten"
-RECOGNITION_MODEL="https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.rten"
+DETECTION_MODEL="https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.onnx"
+RECOGNITION_MODEL="https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.onnx"
 
-curl "$DETECTION_MODEL" -o text-detection.rten
-curl "$RECOGNITION_MODEL" -o text-recognition.rten
+curl "$DETECTION_MODEL" -o text-detection.onnx
+curl "$RECOGNITION_MODEL" -o text-recognition.onnx

--- a/ocrs/examples/hello_ocr.rs
+++ b/ocrs/examples/hello_ocr.rs
@@ -47,8 +47,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
 
     // Use the `download-models.sh` script to download the models.
-    let detection_model_path = file_path("examples/text-detection.rten");
-    let rec_model_path = file_path("examples/text-recognition.rten");
+    let detection_model_path = file_path("examples/text-detection.onnx");
+    let rec_model_path = file_path("examples/text-recognition.onnx");
 
     let detection_model = Model::load_file(detection_model_path)?;
     let recognition_model = Model::load_file(rec_model_path)?;


### PR DESCRIPTION
Enable support for the ONNX model format by default in the `ocrs` crate and change the CLI, examples, C API and documentation to use `.onnx` versions of the existing models.

This change is part of phasing out of support for the custom `.rten` format in the underlying RTen runtime. See https://github.com/robertknight/rten/issues/1470.

The existing `.rten` models will continue to work and are still hosted at the existing location.